### PR TITLE
Update pont-kitchener-marchand.json correction coordonnées

### DIFF
--- a/content/compteurs/voiture/pont-kitchener-marchand.json
+++ b/content/compteurs/voiture/pont-kitchener-marchand.json
@@ -12,8 +12,8 @@
   ],
   "cyclopolisId": "pont-kitchener",
   "coordinates": [
-    4.814421133922526,
-    45.77449789129417
+    4.822335,
+    45.751426
   ],
   "counts": [
     {


### PR DESCRIPTION
Correction coordonnées compteur Kitchener, il était superposé avec le tunnel X Rousse